### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an experimental hack to add [Symfony BASH auto complete](https://github.
 
 ## Installation
 
-1. Run `composer g require stecman/composer-bash-completion-plugin dev-master`
+1. Run `composer global require stecman/composer-bash-completion-plugin dev-master`
 2. Add a completion hook to your shell's user config file:
   - If you're using BASH, put the following in your `~/.bash_profile` file:
 


### PR DESCRIPTION
use `composer global` as it's more concise what is happening, plain `g` maybe easy to type, but it will confuse user (ou, maybe it's typo, need `-g`) and may require user to go seek documentation what does "g" do.
