### PR TITLE
Update stecman/symfony-console-completion dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   },
   "require": {
     "composer-plugin-api": "^1.0|^2.0",
-    "stecman/symfony-console-completion": "~0.7.0"
+    "stecman/symfony-console-completion": "^0.11"
   },
   "require-dev": {
     "composer/composer": "^1.8|^2.0"


### PR DESCRIPTION
Updated the `stecman/symfony-console-completion` dependency to the latest available version (`0.11.0`) to (hopefully) resolve #19.